### PR TITLE
feat: implement shift editing rules with permission checks

### DIFF
--- a/app/(app)/standard/page.tsx
+++ b/app/(app)/standard/page.tsx
@@ -23,20 +23,42 @@ export default function StandardPlanPage() {
   useEffect(() => {
     // Fetch teams
     fetch('/api/teams')
-      .then(res => res.json())
+      .then(res => {
+        if (!res.ok) {
+          throw new Error('Failed to fetch teams')
+        }
+        return res.json()
+      })
       .then(data => {
-        setTeams(data)
-        if (data.length > 0 && !selectedTeamId) {
-          setSelectedTeamId(data[0].id)
+        if (Array.isArray(data)) {
+          setTeams(data)
+          if (data.length > 0 && !selectedTeamId) {
+            setSelectedTeamId(data[0].id)
+          }
+        } else {
+          setTeams([])
         }
       })
-      .catch(console.error)
+      .catch(error => {
+        console.error('Error fetching teams:', error)
+        setTeams([])
+      })
 
     // Fetch users
     fetch('/api/users')
-      .then(res => res.json())
-      .then(data => setUsers(data))
-      .catch(console.error)
+      .then(res => {
+        if (!res.ok) {
+          throw new Error('Failed to fetch users')
+        }
+        return res.json()
+      })
+      .then(data => {
+        setUsers(Array.isArray(data) ? data : [])
+      })
+      .catch(error => {
+        console.error('Error fetching users:', error)
+        setUsers([])
+      })
   }, [])
 
   useEffect(() => {
@@ -46,9 +68,19 @@ export default function StandardPlanPage() {
     const endDate = format(weekDates[6], 'yyyy-MM-dd')
 
     fetch(`/api/shifts?teamId=${selectedTeamId}&dateFrom=${startDate}&dateTo=${endDate}`)
-      .then(res => res.json())
-      .then(data => setShifts(data))
-      .catch(console.error)
+      .then(res => {
+        if (!res.ok) {
+          throw new Error('Failed to fetch shifts')
+        }
+        return res.json()
+      })
+      .then(data => {
+        setShifts(Array.isArray(data) ? data : [])
+      })
+      .catch(error => {
+        console.error('Error fetching shifts:', error)
+        setShifts([])
+      })
   }, [selectedTeamId, weekStart, weekDates])
 
   const handlePrevWeek = () => {
@@ -104,7 +136,7 @@ export default function StandardPlanPage() {
             className="px-3 py-1 rounded-md border bg-background text-foreground"
           >
             <option value="">Alle</option>
-            {users.map(u => (
+            {Array.isArray(users) && users.map(u => (
               <option key={u.id} value={u.id}>{u.name}</option>
             ))}
           </select>
@@ -117,7 +149,7 @@ export default function StandardPlanPage() {
             onChange={(e) => setSelectedTeamId(e.target.value)}
             className="px-3 py-1 rounded-md border bg-background text-foreground"
           >
-            {teams.map(t => (
+            {Array.isArray(teams) && teams.map(t => (
               <option key={t.id} value={t.id}>{t.name}</option>
             ))}
           </select>

--- a/app/api/notes/[id]/approve/route.ts
+++ b/app/api/notes/[id]/approve/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { NoteStatus } from '@prisma/client'
+
+const VALID_NOTE_STATUSES = ['PENDING', 'APPROVED', 'REJECTED'] as const
 
 export async function POST(
   request: Request,
@@ -10,7 +11,7 @@ export async function POST(
     const body = await request.json()
     const { status } = body
 
-    if (!status || !Object.values(NoteStatus).includes(status)) {
+    if (!status || !VALID_NOTE_STATUSES.includes(status as any)) {
       return NextResponse.json({ error: 'Invalid status' }, { status: 400 })
     }
 

--- a/app/api/shifts/route.ts
+++ b/app/api/shifts/route.ts
@@ -2,6 +2,11 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { parse, format } from 'date-fns'
 
+// Helper to check if user can edit shifts (reuses canEditShifts logic)
+function canEditShifts(userRole: string | null): boolean {
+  return userRole === 'ADMIN' || userRole === 'LEADER'
+}
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url)
@@ -53,6 +58,11 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
+    const userRole = request.headers.get('x-user-role')
+    if (!canEditShifts(userRole)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
     const body = await request.json()
     const { date, userId, shiftTypeId, startTime, endTime, comment, teamId } = body
 

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { UserRole } from '@prisma/client'
+
+const VALID_ROLES = ['ADMIN', 'LEADER', 'EMPLOYEE'] as const
 
 export async function PUT(
   request: Request,
@@ -10,7 +11,7 @@ export async function PUT(
     const body = await request.json()
     const { role } = body
 
-    if (!role || !Object.values(UserRole).includes(role)) {
+    if (!role || !VALID_ROLES.includes(role as any)) {
       return NextResponse.json({ error: 'Invalid role' }, { status: 400 })
     }
 

--- a/components/RoleSwitcher.tsx
+++ b/components/RoleSwitcher.tsx
@@ -20,15 +20,28 @@ export function RoleSwitcher() {
   useEffect(() => {
     // Fetch users for role switching
     fetch('/api/users')
-      .then(res => res.json())
+      .then(res => {
+        if (!res.ok) {
+          throw new Error('Failed to fetch users')
+        }
+        return res.json()
+      })
       .then(data => {
-        setUsers(data)
-        // Auto-select first user on mount if no user selected
-        if (!currentUser && data.length > 0) {
-          setCurrentUser(data[0])
+        // Ensure data is an array
+        if (Array.isArray(data)) {
+          setUsers(data)
+          // Auto-select first user on mount if no user selected
+          if (!currentUser && data.length > 0) {
+            setCurrentUser(data[0])
+          }
+        } else {
+          setUsers([])
         }
       })
-      .catch(console.error)
+      .catch(error => {
+        console.error('Error fetching users:', error)
+        setUsers([])
+      })
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleUserSelect = (user: MockUser) => {
@@ -51,7 +64,7 @@ export function RoleSwitcher() {
       <DropdownMenuContent align="end" className="w-56">
         <DropdownMenuLabel>Bytt rolle/bruker</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        {users.map((user) => (
+        {Array.isArray(users) && users.map((user) => (
           <DropdownMenuItem
             key={user.id}
             onClick={() => handleUserSelect(user)}

--- a/components/WeekGrid.tsx
+++ b/components/WeekGrid.tsx
@@ -7,18 +7,23 @@ import { formatHours, calculateShiftHours } from '@/lib/date-utils'
 import { ShiftModal } from './ShiftModal'
 import { MockUser } from '@/lib/auth/mockAuth'
 
+interface ShiftType {
+  id: string
+  code: string
+  label: string
+  color: string
+  defaultStartTime: string
+  defaultEndTime: string
+  crossesMidnight: boolean
+}
+
 interface Shift {
   id: string
   userId: string
   date: string
   startDateTime: string
   endDateTime: string
-  shiftType: {
-    id: string
-    code: string
-    label: string
-    color: string
-  }
+  shiftType: ShiftType
   user: {
     id: string
     name: string

--- a/lib/auth/mockAuth.ts
+++ b/lib/auth/mockAuth.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
-import { UserRole } from '@prisma/client'
+
+export type UserRole = 'ADMIN' | 'LEADER' | 'EMPLOYEE'
 
 export interface MockUser {
   id: string

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,30 +10,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-enum UserRole {
-  ADMIN
-  LEADER
-  EMPLOYEE
-}
-
-enum NoteType {
-  GENERAL
-  ABSENCE
-  SICKNESS
-}
-
-enum NoteStatus {
-  PENDING
-  APPROVED
-  REJECTED
-}
-
-enum SwapRequestStatus {
-  PENDING
-  APPROVED
-  REJECTED
-  EXECUTED
-}
+// Enums removed - SQLite doesn't support enums, using String instead
 
 model Team {
   id        String   @id @default(cuid())
@@ -55,7 +32,7 @@ model User {
   id        String   @id @default(cuid())
   name      String
   email     String   @unique
-  role      UserRole @default(EMPLOYEE)
+  role      String @default("EMPLOYEE")
   teamId    String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -114,8 +91,8 @@ model Note {
   id          String     @id @default(cuid())
   teamId      String
   createdByUserId String
-  type        NoteType
-  status      NoteStatus @default(PENDING)
+  type        String
+  status      String @default("PENDING")
   title       String?
   body        String
   dateFrom    String     // YYYY-MM-DD format
@@ -138,7 +115,7 @@ model SwapRequest {
   fromUserId      String
   toUserId        String
   shiftId         String
-  status          SwapRequestStatus @default(PENDING)
+  status          String @default("PENDING")
   message         String?
   createdAt       DateTime          @default(now())
   decidedBy       String?

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, UserRole, NoteType, NoteStatus, SwapRequestStatus } from '@prisma/client'
+import { PrismaClient } from '@prisma/client'
 import { addDays, parse, format } from 'date-fns'
 
 const prisma = new PrismaClient()
@@ -116,7 +116,7 @@ async function main() {
       data: {
         name: 'Admin User',
         email: 'admin@hdo.no',
-        role: UserRole.ADMIN,
+        role: 'ADMIN',
         teamId: team.id,
       },
     }),
@@ -124,7 +124,7 @@ async function main() {
       data: {
         name: 'Leader User',
         email: 'leader@hdo.no',
-        role: UserRole.LEADER,
+        role: 'LEADER',
         teamId: team.id,
       },
     }),
@@ -132,7 +132,7 @@ async function main() {
       data: {
         name: 'Jan Thomas Kristiansen',
         email: 'jan.thomas.kristiansen@hdo.no',
-        role: UserRole.EMPLOYEE,
+        role: 'EMPLOYEE',
         teamId: team.id,
       },
     }),
@@ -140,7 +140,7 @@ async function main() {
       data: {
         name: 'Erik Heyerdahl',
         email: 'erik.heyerdahl@hdo.no',
-        role: UserRole.EMPLOYEE,
+        role: 'EMPLOYEE',
         teamId: team.id,
       },
     }),
@@ -148,7 +148,7 @@ async function main() {
       data: {
         name: 'Stian Jørgensen',
         email: 'stian.jorgensen@hdo.no',
-        role: UserRole.EMPLOYEE,
+        role: 'EMPLOYEE',
         teamId: team.id,
       },
     }),
@@ -156,7 +156,7 @@ async function main() {
       data: {
         name: 'Gerardas Zozulia',
         email: 'gerardas.zozulia@hdo.no',
-        role: UserRole.EMPLOYEE,
+        role: 'EMPLOYEE',
         teamId: team.id,
       },
     }),
@@ -164,7 +164,7 @@ async function main() {
       data: {
         name: 'Sara Luggenes',
         email: 'sara.luggenes@hdo.no',
-        role: UserRole.EMPLOYEE,
+        role: 'EMPLOYEE',
         teamId: team.id,
       },
     }),
@@ -172,7 +172,7 @@ async function main() {
       data: {
         name: 'Alexander Stenersen',
         email: 'alexander.stenersen@hdo.no',
-        role: UserRole.EMPLOYEE,
+        role: 'EMPLOYEE',
         teamId: team.id,
       },
     }),
@@ -182,7 +182,7 @@ async function main() {
 
   // Seed shifts for 2 weeks starting from 2026-01-05 (Monday, week 2)
   const weekStart = parse('2026-01-05', 'yyyy-MM-dd', new Date())
-  const employees = users.filter(u => u.role === UserRole.EMPLOYEE)
+  const employees = users.filter(u => u.role === 'EMPLOYEE')
 
   // Week 1 shifts (Jan Thomas Kristiansen pattern)
   const week1Employee = employees[0] // Jan Thomas Kristiansen
@@ -336,8 +336,8 @@ async function main() {
     data: {
       teamId: team.id,
       createdByUserId: employees[0].id,
-      type: NoteType.GENERAL,
-      status: NoteStatus.APPROVED,
+      type: 'GENERAL',
+      status: 'APPROVED',
       title: 'Viktig informasjon',
       body: 'Denne uken har ikke noen beskjeder.',
       dateFrom: '2026-01-05',
@@ -350,8 +350,8 @@ async function main() {
     data: {
       teamId: team.id,
       createdByUserId: employees[1].id,
-      type: NoteType.ABSENCE,
-      status: NoteStatus.PENDING,
+      type: 'ABSENCE',
+      status: 'PENDING',
       title: 'Forespørsel om fravær',
       body: 'Ønsker å ta fri 15-16 januar',
       dateFrom: '2026-01-15',


### PR DESCRIPTION
- Add time field editability based on canEditShifts() permission
- Add assignee dropdown for new shifts when user is admin
- Make comment field editable only for users with edit permissions
- Add server-side permission checks in shifts API (POST/PUT/DELETE)
- Fix handleSave to use shift.date when editing existing shift

Server-side changes:
- Add permission guard in /api/shifts POST endpoint
- Add permission guard in /api/shifts/[id] PUT and DELETE endpoints
- Reuse canEditShifts() logic (ADMIN or LEADER only)

Build fixes:
- Replace Prisma enum imports with string literals (SQLite compatibility)
- Update WeekGrid ShiftType interface for type compatibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Server-side permissions**: Add `canEditShifts` guard to `POST /api/shifts`, `PUT /api/shifts/[id]`, and `DELETE /api/shifts/[id]` using `x-user-role` (ADMIN/LEADER only). Improve validation in `users` and `notes` routes by validating roles/statuses against string lists.
> - **UI behavior**: In `ShiftModal`, show editable time/comment fields only when `canEditShifts()`; allow ADMIN to choose assignee for new shifts; send `x-user-role` on save/delete; fix save to use `shift.date` when editing; render read-only details when not editable. Add `currentUser` plumbed through `WeekGrid` and `StandardPlanPage`. Harden fetch handling and array checks in multiple components.
> - **Database/schema**: Replace Prisma enums with string fields in `schema.prisma` (roles, note types/status, swap status) and update `seed.ts` accordingly. Expand `ShiftType` interface to include defaults and `crossesMidnight`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d0fd0a8149ecd3b007b5ec46fa26cc9c63f5b5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->