### PR TITLE
Fix shift comment save

### DIFF
--- a/components/ShiftModal.tsx
+++ b/components/ShiftModal.tsx
@@ -24,7 +24,7 @@ import { MockUser } from '@/lib/auth/mockAuth'
 import { useAuth } from '@/lib/auth/mockAuth'
 import { formatTime, formatDateDisplay, formatDayName } from '@/lib/date-utils'
 
-interface ShiftType {
+export interface ShiftType {
   id: string
   code: string
   label: string
@@ -34,7 +34,7 @@ interface ShiftType {
   crossesMidnight: boolean
 }
 
-interface Shift {
+export interface Shift {
   id: string
   userId: string
   date: string
@@ -96,12 +96,13 @@ export function ShiftModal({ shift, date, userId, onClose, currentUser }: ShiftM
   }, [shift, date, shiftTypes])
 
   const handleSave = async () => {
-    if (!date || !selectedShiftTypeId || !selectedUserId) return
+    const effectiveDate = shift?.date ?? date
+    if (!effectiveDate || !selectedShiftTypeId || !selectedUserId) return
 
     setIsSaving(true)
     try {
       const shiftData = {
-        date,
+        date: effectiveDate,
         userId: selectedUserId,
         shiftTypeId: selectedShiftTypeId,
         startTime,


### PR DESCRIPTION
## What changed?
- Use shift date when saving existing shift comment

## Why?
- Save bailed out when date was null for existing shifts

## How to test?
- Open existing shift → add comment → save → reload

## Screenshots (UI changes)
- NA

## Checklist
- [ok] I ran the app locally
- [ok] I kept the PR small and focused
- [ok] No secrets (.env, tokens) were committed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes date handling when saving shifts and exposes types for reuse.
> 
> - In `ShiftModal.tsx`, `handleSave` now derives `effectiveDate` via `shift?.date ?? date` and sends `date: effectiveDate`, allowing saves when the `date` prop is null for existing shifts
> - Exports `ShiftType` and `Shift` interfaces
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a1eb36cf348a5bd002449ff4b0b8032aeeb268e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->