### PR TITLE
Feature/bulk shifts v2

### DIFF
--- a/app/(app)/admin/layout.tsx
+++ b/app/(app)/admin/layout.tsx
@@ -1,3 +1,4 @@
+/** Layout wrapper for admin routes. */
 export default function AdminLayout({
   children,
 }: {

--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { Users, Calendar, Settings, Building2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
+/** Admin landing page with links to management sections. */
 export default function AdminPage() {
   return (
     <div className="space-y-6">

--- a/app/(app)/admin/settings/page.tsx
+++ b/app/(app)/admin/settings/page.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 
+/** Admin page for notification settings per team. */
 export default function SettingsPage() {
   const [teams, setTeams] = useState<any[]>([])
   const [selectedTeamId, setSelectedTeamId] = useState<string>('')

--- a/app/(app)/admin/shift-types/page.tsx
+++ b/app/(app)/admin/shift-types/page.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog'
 import { Plus, Trash2, Edit } from 'lucide-react'
 
+/** Admin page to manage shift types and colors. */
 export default function ShiftTypesPage() {
   const [shiftTypes, setShiftTypes] = useState<any[]>([])
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)

--- a/app/(app)/admin/teams/page.tsx
+++ b/app/(app)/admin/teams/page.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog'
 import { Plus, Trash2 } from 'lucide-react'
 
+/** Admin page to create and remove teams. */
 export default function TeamsPage() {
   const [teams, setTeams] = useState<any[]>([])
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)

--- a/app/(app)/admin/users/page.tsx
+++ b/app/(app)/admin/users/page.tsx
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 
+/** Admin page to manage user roles. */
 export default function UsersPage() {
   const [users, setUsers] = useState<any[]>([])
   const [teams, setTeams] = useState<any[]>([])

--- a/app/(app)/agenda/page.tsx
+++ b/app/(app)/agenda/page.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 
+/** Agenda view showing upcoming shifts and notes. */
 export default function AgendaPage() {
   const [shifts, setShifts] = useState<any[]>([])
   const [notes, setNotes] = useState<any[]>([])

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { Navigation } from '@/components/Navigation'
 import { Toaster } from '@/components/ui/toaster'
 
+/** Shared layout for authenticated app routes. */
 export default function AppLayout({
   children,
 }: {

--- a/app/(app)/month/page.tsx
+++ b/app/(app)/month/page.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '@/lib/auth/mockAuth'
 import { formatDateDisplay } from '@/lib/date-utils'
 import { ShiftModal } from '@/components/ShiftModal'
 
+/** Monthly calendar view of shifts with per-day summaries. */
 export default function MonthPage() {
   const [selectedDate, setSelectedDate] = useState(new Date())
   const [shifts, setShifts] = useState<any[]>([])

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation'
 
+/** Redirect app root to the standard schedule view. */
 export default function HomePage() {
   redirect('/standard')
 }

--- a/app/(app)/standard/page.tsx
+++ b/app/(app)/standard/page.tsx
@@ -5,6 +5,7 @@ import { format, addWeeks, subWeeks } from 'date-fns'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { WeekGrid } from '@/components/WeekGrid'
+import { BulkShiftModal } from '@/components/BulkShiftModal'
 import { useAuth } from '@/lib/auth/mockAuth'
 import { getWeekStart, getWeekDates as getWeekDatesUtil, formatDateDisplay, formatDayName } from '@/lib/date-utils'
 
@@ -16,7 +17,8 @@ export default function StandardPlanPage() {
   const [teams, setTeams] = useState<any[]>([])
   const [selectedTeamId, setSelectedTeamId] = useState<string>('')
   const [selectedUserId, setSelectedUserId] = useState<string>('')
-  const { currentUser } = useAuth()
+  const { currentUser, canEditShifts } = useAuth()
+  const [isBulkModalOpen, setIsBulkModalOpen] = useState(false)
 
   const weekStart = useMemo(() => getWeekStart(selectedDate), [selectedDate])
   const weekDates = useMemo(() => getWeekDatesUtil(selectedDate), [selectedDate])
@@ -83,6 +85,11 @@ export default function StandardPlanPage() {
           <Button variant="outline" onClick={handleNextWeek} size="icon">
             <ChevronRight className="h-4 w-4" />
           </Button>
+          {canEditShifts() && selectedTeamId && (
+            <Button variant="outline" onClick={() => setIsBulkModalOpen(true)}>
+              Bulk endring
+            </Button>
+          )}
         </div>
       </div>
 
@@ -131,6 +138,13 @@ export default function StandardPlanPage() {
         shifts={shifts}
         currentUser={currentUser}
       />
+
+      {isBulkModalOpen && selectedTeamId && (
+        <BulkShiftModal
+          teamId={selectedTeamId}
+          onClose={() => setIsBulkModalOpen(false)}
+        />
+      )}
     </div>
   )
 }

--- a/app/(app)/standard/page.tsx
+++ b/app/(app)/standard/page.tsx
@@ -8,6 +8,7 @@ import { WeekGrid } from '@/components/WeekGrid'
 import { useAuth } from '@/lib/auth/mockAuth'
 import { getWeekStart, getWeekDates as getWeekDatesUtil, formatDateDisplay, formatDayName } from '@/lib/date-utils'
 
+/** Standard weekly schedule view with team and user filters. */
 export default function StandardPlanPage() {
   const [selectedDate, setSelectedDate] = useState(new Date())
   const [shifts, setShifts] = useState<any[]>([])

--- a/app/(app)/swap/page.tsx
+++ b/app/(app)/swap/page.tsx
@@ -23,6 +23,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 
+/** Shift swap request page with create/approve flows. */
 export default function SwapPage() {
   const [swapRequests, setSwapRequests] = useState<any[]>([])
   const [shifts, setShifts] = useState<any[]>([])

--- a/app/api/notes/[id]/approve/route.ts
+++ b/app/api/notes/[id]/approve/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { NoteStatus } from '@prisma/client'
 
+/** Approve or reject a note by id and notify the creator. */
 export async function POST(
   request: Request,
   { params }: { params: { id: string } }

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** List notes for a team, optionally within a date range. */
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url)
@@ -43,6 +44,7 @@ export async function GET(request: Request) {
   }
 }
 
+/** Create a note and notify the creator. */
 export async function POST(request: Request) {
   try {
     const body = await request.json()

--- a/app/api/notification-settings/route.ts
+++ b/app/api/notification-settings/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** Get notification settings for a team, creating defaults if missing. */
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url)
@@ -32,6 +33,7 @@ export async function GET(request: Request) {
   }
 }
 
+/** Upsert notification settings for a team. */
 export async function PUT(request: Request) {
   try {
     const body = await request.json()

--- a/app/api/notifications/[id]/read/route.ts
+++ b/app/api/notifications/[id]/read/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** Mark a notification as read. */
 export async function POST(
   request: Request,
   { params }: { params: { id: string } }

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** List notifications for a user or team. */
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url)

--- a/app/api/shift-types/[id]/route.ts
+++ b/app/api/shift-types/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** Update a shift type by id. */
 export async function PUT(
   request: Request,
   { params }: { params: { id: string } }
@@ -28,6 +29,7 @@ export async function PUT(
   }
 }
 
+/** Delete a shift type by id. */
 export async function DELETE(
   request: Request,
   { params }: { params: { id: string } }

--- a/app/api/shift-types/route.ts
+++ b/app/api/shift-types/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** List all shift types. */
 export async function GET() {
   try {
     const shiftTypes = await prisma.shiftType.findMany({
@@ -14,6 +15,7 @@ export async function GET() {
   }
 }
 
+/** Create a new shift type. */
 export async function POST(request: Request) {
   try {
     const body = await request.json()

--- a/app/api/shifts/[id]/route.ts
+++ b/app/api/shifts/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { parse } from 'date-fns'
 
+/** Update a shift by id and notify the affected user. */
 export async function PUT(
   request: Request,
   { params }: { params: { id: string } }
@@ -72,6 +73,7 @@ export async function PUT(
   }
 }
 
+/** Delete a shift by id and notify the affected user. */
 export async function DELETE(
   request: Request,
   { params }: { params: { id: string } }

--- a/app/api/shifts/bulk/route.ts
+++ b/app/api/shifts/bulk/route.ts
@@ -1,0 +1,253 @@
+import { NextResponse } from 'next/server'
+import { parse } from 'date-fns'
+import { prisma } from '@/lib/prisma'
+
+type BulkAction = 'create' | 'update' | 'delete'
+
+interface BulkShiftItem {
+  shiftId?: string
+  userId?: string
+  date?: string
+  shiftTypeId?: string
+  startTime?: string
+  endTime?: string
+  comment?: string
+}
+
+interface BulkShiftRequest {
+  action: BulkAction
+  teamId?: string
+  items: BulkShiftItem[]
+  currentUserId?: string
+}
+
+const dateRegex = /^\d{4}-\d{2}-\d{2}$/
+const timeRegex = /^\d{2}:\d{2}$/
+const MAX_ITEMS = 200
+const BATCH_SIZE = 20
+
+/** Bulk create, update, or delete shifts for multiple users and dates. */
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as BulkShiftRequest
+    const { action, items, currentUserId } = body
+
+    if (!currentUserId) {
+      return NextResponse.json({ error: 'currentUserId is required' }, { status: 401 })
+    }
+
+    const currentUser = await prisma.user.findUnique({ where: { id: currentUserId } })
+    if (!currentUser || (currentUser.role !== 'ADMIN' && currentUser.role !== 'LEADER')) {
+      return NextResponse.json({ error: 'Not authorized' }, { status: 403 })
+    }
+
+    const teamId = body.teamId || currentUser.teamId
+    if (!teamId) {
+      return NextResponse.json({ error: 'teamId is required' }, { status: 400 })
+    }
+
+    if (!action || !['create', 'update', 'delete'].includes(action)) {
+      return NextResponse.json({ error: 'Invalid action' }, { status: 400 })
+    }
+
+    if (!Array.isArray(items) || items.length === 0) {
+      return NextResponse.json({ error: 'items is required' }, { status: 400 })
+    }
+
+    if (items.length > MAX_ITEMS) {
+      return NextResponse.json({ error: `Too many items (max ${MAX_ITEMS})` }, { status: 400 })
+    }
+
+    const uniqueUserIds = Array.from(
+      new Set(items.map(item => item.userId).filter(Boolean)) as Set<string>
+    )
+    const users = uniqueUserIds.length > 0
+      ? await prisma.user.findMany({
+          where: { id: { in: uniqueUserIds } },
+          select: { id: true, teamId: true },
+        })
+      : []
+    const userMap = new Map(users.map(user => [user.id, user]))
+
+    const uniqueShiftTypeIds = Array.from(
+      new Set(items.map(item => item.shiftTypeId).filter(Boolean)) as Set<string>
+    )
+    const shiftTypes = uniqueShiftTypeIds.length > 0
+      ? await prisma.shiftType.findMany({ where: { id: { in: uniqueShiftTypeIds } } })
+      : []
+    const shiftTypeMap = new Map(shiftTypes.map(shiftType => [shiftType.id, shiftType]))
+
+    const successes: Array<{ userId: string; date: string; shiftId?: string }> = []
+    const failures: Array<{ userId: string; date: string; error: string }> = []
+
+    const processItem = async (item: BulkShiftItem) => {
+      let userId = item.userId
+      let date = item.date
+      let existingShift = null as null | { id: string; userId: string; date: string }
+
+      if (item.shiftId) {
+        const shift = await prisma.shift.findUnique({
+          where: { id: item.shiftId },
+          select: { id: true, userId: true, date: true, teamId: true },
+        })
+        if (!shift || shift.teamId !== teamId) {
+          return { status: 'failure', userId: userId || '', date: date || '', error: 'Shift not found' }
+        }
+        existingShift = { id: shift.id, userId: shift.userId, date: shift.date }
+        userId = shift.userId
+        date = shift.date
+      }
+
+      if (action === 'create' && (!userId || !date)) {
+        return { status: 'failure', userId: userId || '', date: date || '', error: 'userId and date are required' }
+      }
+
+      if (!userId || !date) {
+        return { status: 'failure', userId: userId || '', date: date || '', error: 'Shift is required' }
+      }
+
+      if (!dateRegex.test(date)) {
+        return { status: 'failure', userId, date, error: 'Invalid date format' }
+      }
+
+      const user = userMap.get(userId) || (await prisma.user.findUnique({ where: { id: userId } }))
+      if (!user) {
+        return { status: 'failure', userId, date, error: 'User not found' }
+      }
+      if (user.teamId !== teamId) {
+        return { status: 'failure', userId, date, error: 'User must belong to team' }
+      }
+
+      let shiftType = null
+      if (action !== 'delete') {
+        if (!item.shiftTypeId || !item.startTime || !item.endTime) {
+          return { status: 'failure', userId, date, error: 'shiftTypeId, startTime, and endTime are required' }
+        }
+        if (!timeRegex.test(item.startTime) || !timeRegex.test(item.endTime)) {
+          return { status: 'failure', userId, date, error: 'Invalid time format' }
+        }
+        shiftType = shiftTypeMap.get(item.shiftTypeId)
+        if (!shiftType) {
+          return { status: 'failure', userId, date, error: 'Shift type not found' }
+        }
+      }
+
+      if (!existingShift) {
+        existingShift = await prisma.shift.findFirst({
+          where: { userId, date, teamId },
+          select: { id: true, userId: true, date: true },
+        })
+      }
+
+      if (action === 'create') {
+        if (existingShift) {
+          return { status: 'failure', userId, date, error: 'Shift already exists' }
+        }
+
+        const startDateTime = parse(`${date}T${item.startTime}`, "yyyy-MM-dd'T'HH:mm", new Date())
+        let endDateTime = parse(`${date}T${item.endTime}`, "yyyy-MM-dd'T'HH:mm", new Date())
+        if (shiftType?.crossesMidnight || endDateTime <= startDateTime) {
+          endDateTime = new Date(endDateTime.getTime() + 24 * 60 * 60 * 1000)
+        }
+
+        const created = await prisma.shift.create({
+          data: {
+            teamId,
+            userId,
+            date,
+            startDateTime,
+            endDateTime,
+            shiftTypeId: shiftType!.id,
+            comment: item.comment || null,
+          },
+        })
+
+        await prisma.notification.create({
+          data: {
+            teamId,
+            userId,
+            type: 'SHIFT_CREATED',
+            title: 'Vakt opprettet',
+            message: `Ny vakt opprettet for ${date}`,
+          },
+        })
+
+        return { status: 'success', userId, date, shiftId: created.id }
+      }
+
+      if (action === 'update') {
+        if (!existingShift) {
+          return { status: 'failure', userId, date, error: 'Shift not found' }
+        }
+
+        const startDateTime = parse(`${date}T${item.startTime}`, "yyyy-MM-dd'T'HH:mm", new Date())
+        let endDateTime = parse(`${date}T${item.endTime}`, "yyyy-MM-dd'T'HH:mm", new Date())
+        if (shiftType?.crossesMidnight || endDateTime <= startDateTime) {
+          endDateTime = new Date(endDateTime.getTime() + 24 * 60 * 60 * 1000)
+        }
+
+        const updated = await prisma.shift.update({
+          where: { id: existingShift.id },
+          data: {
+            startDateTime,
+            endDateTime,
+            shiftTypeId: shiftType!.id,
+            comment: item.comment || null,
+          },
+        })
+
+        await prisma.notification.create({
+          data: {
+            teamId,
+            userId,
+            type: 'SHIFT_UPDATED',
+            title: 'Vakt oppdatert',
+            message: `Vakt oppdatert for ${date}`,
+          },
+        })
+
+        return { status: 'success', userId, date, shiftId: updated.id }
+      }
+
+      if (!existingShift) {
+        return { status: 'failure', userId, date, error: 'Shift not found' }
+      }
+
+      await prisma.shift.delete({ where: { id: existingShift.id } })
+      await prisma.notification.create({
+        data: {
+          teamId,
+          userId,
+          type: 'SHIFT_DELETED',
+          title: 'Vakt slettet',
+          message: `Vakt slettet for ${date}`,
+        },
+      })
+
+      return { status: 'success', userId, date, shiftId: existingShift.id }
+    }
+
+    for (let i = 0; i < items.length; i += BATCH_SIZE) {
+      const batch = items.slice(i, i + BATCH_SIZE)
+      const results = await Promise.allSettled(batch.map(item => processItem(item)))
+
+      results.forEach(result => {
+        if (result.status !== 'fulfilled') {
+          return
+        }
+        const value = result.value
+        if (value.status === 'success') {
+          successes.push({ userId: value.userId, date: value.date, shiftId: value.shiftId })
+        } else {
+          failures.push({ userId: value.userId, date: value.date, error: value.error })
+        }
+      })
+    }
+
+    return NextResponse.json({ successes, failures })
+  } catch (error) {
+    console.error('Error processing bulk shifts:', error)
+    return NextResponse.json({ error: 'Failed to process bulk shifts' }, { status: 500 })
+  }
+}
+

--- a/app/api/shifts/route.ts
+++ b/app/api/shifts/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { parse, format } from 'date-fns'
 
+/** List shifts for a team, optionally filtered by date range or user. */
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url)
@@ -51,6 +52,7 @@ export async function GET(request: Request) {
   }
 }
 
+/** Create a shift and emit a notification for the affected user. */
 export async function POST(request: Request) {
   try {
     const body = await request.json()

--- a/app/api/swap-requests/[id]/approve/route.ts
+++ b/app/api/swap-requests/[id]/approve/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** Approve a swap request by id and notify the requester. */
 export async function POST(
   request: Request,
   { params }: { params: { id: string } }

--- a/app/api/swap-requests/[id]/execute/route.ts
+++ b/app/api/swap-requests/[id]/execute/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** Execute an approved swap request and notify both users. */
 export async function POST(
   request: Request,
   { params }: { params: { id: string } }

--- a/app/api/swap-requests/[id]/reject/route.ts
+++ b/app/api/swap-requests/[id]/reject/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** Reject a swap request by id and notify the requester. */
 export async function POST(
   request: Request,
   { params }: { params: { id: string } }

--- a/app/api/swap-requests/route.ts
+++ b/app/api/swap-requests/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** List swap requests for a team. */
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url)
@@ -47,6 +48,7 @@ export async function GET(request: Request) {
   }
 }
 
+/** Create a swap request and notify the team. */
 export async function POST(request: Request) {
   try {
     const body = await request.json()

--- a/app/api/teams/[id]/route.ts
+++ b/app/api/teams/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** Delete a team by id. */
 export async function DELETE(
   request: Request,
   { params }: { params: { id: string } }

--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** List all teams. */
 export async function GET() {
   try {
     const teams = await prisma.team.findMany({
@@ -14,6 +15,7 @@ export async function GET() {
   }
 }
 
+/** Create a team and default notification settings. */
 export async function POST(request: Request) {
   try {
     const body = await request.json()

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { UserRole } from '@prisma/client'
 
+/** Update a user's role by id. */
 export async function PUT(
   request: Request,
   { params }: { params: { id: string } }

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+/** List all users. */
 export async function GET() {
   try {
     const users = await prisma.user.findMany({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,11 +4,13 @@ import "./globals.css"
 
 const inter = Inter({ subsets: ["latin"] })
 
+/** Global app metadata for the Next.js document head. */
 export const metadata: Metadata = {
   title: "HDO Turnusplan",
   description: "Shift scheduling system for HDO",
 }
 
+/** Root HTML layout wrapper for the entire app. */
 export default function RootLayout({
   children,
 }: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation'
 
+/** Redirect root route to the standard schedule view. */
 export default function Home() {
   redirect('/standard')
 }

--- a/components/BulkShiftModal.tsx
+++ b/components/BulkShiftModal.tsx
@@ -1,0 +1,487 @@
+"use client"
+
+import { useEffect, useMemo, useState } from 'react'
+import { format, subDays } from 'date-fns'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useAuth } from '@/lib/auth/mockAuth'
+
+type BulkAction = 'create' | 'update' | 'delete'
+
+interface BulkShiftModalProps {
+  teamId: string
+  onClose: () => void
+}
+
+interface ShiftType {
+  id: string
+  label: string
+  defaultStartTime: string
+  defaultEndTime: string
+  crossesMidnight: boolean
+}
+
+interface UserSummary {
+  id: string
+  name: string
+  teamId: string
+}
+
+interface BulkShiftRow {
+  id: string
+  shiftId?: string
+  userId: string
+  date: string
+  shiftTypeId: string
+  startTime: string
+  endTime: string
+  comment: string
+  useCustomTime: boolean
+}
+
+const MAX_ROWS = 200
+const SHIFT_LOOKBACK_DAYS = 30
+const SHIFT_LOOKAHEAD_DAYS = 90
+
+/** Modal for bulk create/update/delete of shifts across users and dates. */
+export function BulkShiftModal({ teamId, onClose }: BulkShiftModalProps) {
+  const { currentUser } = useAuth()
+  const [action, setAction] = useState<BulkAction>('create')
+  const [shiftTypes, setShiftTypes] = useState<ShiftType[]>([])
+  const [users, setUsers] = useState<UserSummary[]>([])
+  const [rows, setRows] = useState<BulkShiftRow[]>([])
+  const [isSaving, setIsSaving] = useState(false)
+  const [result, setResult] = useState<{
+    successes: Array<{ userId: string; date: string; shiftId?: string }>
+    failures: Array<{ userId: string; date: string; error: string }>
+  } | null>(null)
+  const [teamShifts, setTeamShifts] = useState<any[]>([])
+
+  useEffect(() => {
+    fetch('/api/shift-types')
+      .then(res => res.json())
+      .then(data => {
+        setShiftTypes(data)
+      })
+      .catch(console.error)
+
+    fetch('/api/users')
+      .then(res => res.json())
+      .then(data => setUsers(data))
+      .catch(console.error)
+  }, [])
+
+  useEffect(() => {
+    if (!teamId) return
+    const today = new Date()
+    const dateFrom = format(subDays(today, SHIFT_LOOKBACK_DAYS), 'yyyy-MM-dd')
+    const dateTo = format(new Date(today.getTime() + SHIFT_LOOKAHEAD_DAYS * 24 * 60 * 60 * 1000), 'yyyy-MM-dd')
+
+    fetch(`/api/shifts?teamId=${teamId}&dateFrom=${dateFrom}&dateTo=${dateTo}`)
+      .then(res => res.json())
+      .then(data => setTeamShifts(data))
+      .catch(console.error)
+  }, [teamId])
+
+  const defaultShiftType = useMemo(() => shiftTypes[0] || null, [shiftTypes])
+  const userNameById = useMemo(
+    () => new Map(users.map(user => [user.id, user.name])),
+    [users]
+  )
+  const teamUsers = useMemo(() => users.filter(user => user.teamId === teamId), [users, teamId])
+  const shiftTypeById = useMemo(
+    () => new Map(shiftTypes.map(shiftType => [shiftType.id, shiftType])),
+    [shiftTypes]
+  )
+  const shiftsById = useMemo(
+    () => new Map(teamShifts.map(shift => [shift.id, shift])),
+    [teamShifts]
+  )
+  const shiftsForDropdown = useMemo(
+    () => teamShifts.map(shift => ({
+      id: shift.id,
+      userId: shift.userId,
+      date: shift.date,
+      shiftTypeId: shift.shiftTypeId,
+      startTime: format(new Date(shift.startDateTime), 'HH:mm'),
+      endTime: format(new Date(shift.endDateTime), 'HH:mm'),
+      label: `${userNameById.get(shift.userId) || 'Ukjent'} · ${shift.date} · ${shift.shiftType?.label || 'Vakt'} (${format(new Date(shift.startDateTime), 'HH:mm')}-${format(new Date(shift.endDateTime), 'HH:mm')})`,
+    })),
+    [teamShifts, userNameById]
+  )
+  const shiftsPerDate = useMemo(() => {
+    const map = new Map<string, number>()
+    teamShifts.forEach(shift => {
+      map.set(shift.date, (map.get(shift.date) || 0) + 1)
+    })
+    return map
+  }, [teamShifts])
+
+  const createRow = (): BulkShiftRow => ({
+    id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    shiftId: undefined,
+    userId: '',
+    date: '',
+    shiftTypeId: defaultShiftType?.id || '',
+    startTime: defaultShiftType?.defaultStartTime || '',
+    endTime: defaultShiftType?.defaultEndTime || '',
+    comment: '',
+    useCustomTime: false,
+  })
+
+  useEffect(() => {
+    if (!defaultShiftType || rows.length === 0) return
+    setRows(prev =>
+      prev.map(row => (
+        row.shiftTypeId
+          ? row
+          : {
+              ...row,
+              shiftTypeId: defaultShiftType.id,
+              startTime: defaultShiftType.defaultStartTime,
+              endTime: defaultShiftType.defaultEndTime,
+            }
+      ))
+    )
+  }, [defaultShiftType, rows.length])
+
+  useEffect(() => {
+    if (shiftTypes.length > 0 && rows.length === 0) {
+      setRows([createRow()])
+    }
+  }, [shiftTypes.length, rows.length])
+
+  const addRow = () => {
+    if (rows.length >= MAX_ROWS) return
+    setRows(prev => [...prev, createRow()])
+    setResult(null)
+  }
+
+  const duplicateRow = (rowId: string) => {
+    const row = rows.find(item => item.id === rowId)
+    if (!row || rows.length >= MAX_ROWS) return
+    setRows(prev => [...prev, { ...row, id: createRow().id }])
+    setResult(null)
+  }
+
+  const removeRow = (rowId: string) => {
+    setRows(prev => prev.filter(item => item.id !== rowId))
+    setResult(null)
+  }
+
+  const updateRow = (rowId: string, updates: Partial<BulkShiftRow>) => {
+    setRows(prev => prev.map(item => (item.id === rowId ? { ...item, ...updates } : item)))
+    setResult(null)
+  }
+
+  const canSubmit = () => {
+    if (!currentUser) return false
+    if (!teamId || rows.length === 0 || rows.length > MAX_ROWS) return false
+    return rows.every(row => {
+      if (action === 'create' && (!row.userId || !row.date)) return false
+      if (action !== 'create' && !row.shiftId) return false
+      if (action === 'delete') return Boolean(row.shiftId)
+      return Boolean(row.shiftTypeId && row.startTime && row.endTime)
+    })
+  }
+
+  const handleSave = async () => {
+    if (!canSubmit() || !currentUser) return
+
+    setIsSaving(true)
+    try {
+      const response = await fetch('/api/shifts/bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action,
+          teamId,
+          items: rows.map(row => ({
+            shiftId: row.shiftId,
+            userId: row.userId,
+            date: row.date,
+            shiftTypeId: row.shiftTypeId || undefined,
+            startTime: row.startTime || undefined,
+            endTime: row.endTime || undefined,
+            comment: row.comment || undefined,
+          })),
+          currentUserId: currentUser.id,
+        }),
+      })
+
+      const data = await response.json()
+      if (response.ok) {
+        const failures = data.failures?.length || 0
+        const successes = data.successes?.length || 0
+        if (failures > 0) {
+          setResult({ successes: data.successes || [], failures: data.failures || [] })
+          alert(`Fullført med ${successes} suksess(er) og ${failures} feil.`)
+          return
+        }
+        setResult({ successes: data.successes || [], failures: [] })
+        onClose()
+        window.location.reload()
+      } else {
+        alert(data?.error || 'Kunne ikke oppdatere vakter')
+      }
+    } catch (error) {
+      console.error('Error bulk updating shifts:', error)
+      alert('Kunne ikke oppdatere vakter')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={true} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Bulk vaktendring</DialogTitle>
+          <DialogDescription>
+            Opprett, oppdater eller slett vakter i en tabell med ulike datoer og tider.
+          </DialogDescription>
+        </DialogHeader>
+
+          <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label>Handling</Label>
+            <Select value={action} onValueChange={(value) => setAction(value as BulkAction)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="create">Opprett</SelectItem>
+                <SelectItem value="update">Oppdater</SelectItem>
+                <SelectItem value="delete">Slett</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-sm text-muted-foreground">
+              {rows.length} rad(er) valgt
+              {rows.length > MAX_ROWS && ` (maks ${MAX_ROWS})`}
+            </div>
+            <Button variant="outline" onClick={addRow} disabled={rows.length >= MAX_ROWS}>
+              Legg til rad
+            </Button>
+          </div>
+
+          {rows.length === 0 && (
+            <div className="text-sm text-muted-foreground">
+              Ingen rader lagt til ennå. Klikk “Legg til rad”.
+            </div>
+          )}
+
+          <div className="grid gap-3">
+            {rows.map(row => {
+              const isCreate = action === 'create'
+              const isUpdate = action === 'update'
+              const isDelete = action === 'delete'
+              const scheduledCount = row.date ? (shiftsPerDate.get(row.date) || 0) : null
+              const capacity = teamUsers.length
+              const available = capacity ? Math.max(0, capacity - (scheduledCount || 0)) : null
+
+              return (
+                <div key={row.id} className="rounded-md border p-3">
+                  {isCreate && (
+                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                      <div className="grid gap-2">
+                        <Label>Ansatt</Label>
+                        <Select
+                          value={row.userId}
+                          onValueChange={(value) => updateRow(row.id, { userId: value })}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Velg ansatt" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {teamUsers.map(user => (
+                              <SelectItem key={user.id} value={user.id}>
+                                {user.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="grid gap-2">
+                        <Label>Dato</Label>
+                        <Input
+                          type="date"
+                          value={row.date}
+                          onChange={(e) => updateRow(row.id, { date: e.target.value })}
+                        />
+                        {row.date && capacity > 0 && (
+                          <div className="text-xs text-muted-foreground">
+                            Planlagt: {scheduledCount} / {capacity} · Ledig: {available}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {!isCreate && (
+                    <div className="grid gap-2">
+                      <Label>Oppsatt vakt</Label>
+                      <Select
+                        value={row.shiftId || ''}
+                        onValueChange={(value) => {
+                          const shift = shiftsById.get(value)
+                          if (!shift) {
+                            updateRow(row.id, { shiftId: value })
+                            return
+                          }
+                          updateRow(row.id, {
+                            shiftId: value,
+                            userId: shift.userId,
+                            date: shift.date,
+                            shiftTypeId: shift.shiftTypeId,
+                            startTime: format(new Date(shift.startDateTime), 'HH:mm'),
+                            endTime: format(new Date(shift.endDateTime), 'HH:mm'),
+                            comment: shift.comment || '',
+                            useCustomTime: false,
+                          })
+                        }}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Velg vakt" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {shiftsForDropdown.map(shift => (
+                            <SelectItem key={shift.id} value={shift.id}>
+                              {shift.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+
+                  {(isCreate || isUpdate) && (
+                    <div className="mt-3 grid gap-2">
+                      <Label>Vakt</Label>
+                      <Select
+                        value={row.shiftTypeId}
+                        onValueChange={(value) => {
+                          const selected = shiftTypeById.get(value)
+                          updateRow(row.id, {
+                            shiftTypeId: value,
+                            startTime: selected?.defaultStartTime || row.startTime,
+                            endTime: selected?.defaultEndTime || row.endTime,
+                            useCustomTime: false,
+                          })
+                        }}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Velg vakt" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {shiftTypes.map(st => (
+                            <SelectItem key={st.id} value={st.id}>
+                              {st.label} ({st.defaultStartTime}-{st.defaultEndTime})
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+
+                  {(isCreate || isUpdate) && (
+                    <div className="mt-3 grid gap-2">
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={row.useCustomTime}
+                          onChange={(e) => updateRow(row.id, { useCustomTime: e.target.checked })}
+                        />
+                        <Label>Tilpass tid</Label>
+                      </div>
+                      {row.useCustomTime && (
+                        <div className="grid grid-cols-2 gap-2">
+                          <div className="grid gap-2">
+                            <Label>Start</Label>
+                            <Input
+                              type="time"
+                              value={row.startTime}
+                              onChange={(e) => updateRow(row.id, { startTime: e.target.value })}
+                            />
+                          </div>
+                          <div className="grid gap-2">
+                            <Label>Slutt</Label>
+                            <Input
+                              type="time"
+                              value={row.endTime}
+                              onChange={(e) => updateRow(row.id, { endTime: e.target.value })}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {(isCreate || isUpdate) && (
+                    <div className="mt-3 grid gap-2">
+                      <Label>Kommentar (valgfritt)</Label>
+                      <Input
+                        value={row.comment}
+                        onChange={(e) => updateRow(row.id, { comment: e.target.value })}
+                      />
+                    </div>
+                  )}
+
+                  <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
+                    <Button variant="ghost" onClick={() => duplicateRow(row.id)}>
+                      Dupliser
+                    </Button>
+                    <Button variant="ghost" onClick={() => removeRow(row.id)}>
+                      Fjern
+                    </Button>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+
+          {result && result.failures.length > 0 && (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm">
+              <div className="font-medium">Noen rader feilet</div>
+              <div className="mt-2 space-y-1">
+                {result.failures.map((failure, index) => (
+                  <div key={`${failure.userId}-${failure.date}-${index}`}>
+                    {userNameById.get(failure.userId) || failure.userId} · {failure.date} · {failure.error}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Avbryt
+          </Button>
+          <Button onClick={handleSave} disabled={!canSubmit() || isSaving}>
+            {isSaving ? 'Lagrer...' : 'Utfør'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -16,6 +16,7 @@ const navItems = [
   { href: '/admin', label: 'Admin', icon: Lock },
 ]
 
+/** Primary top navigation for the app pages. */
 export function Navigation() {
   const pathname = usePathname()
 

--- a/components/NotificationsPanel.tsx
+++ b/components/NotificationsPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/dialog'
 import { useAuth } from '@/lib/auth/mockAuth'
 
+/** Notification bell with polling and mark-as-read handling. */
 export function NotificationsPanel() {
   const [notifications, setNotifications] = useState<any[]>([])
   const [isOpen, setIsOpen] = useState(false)

--- a/components/RoleSwitcher.tsx
+++ b/components/RoleSwitcher.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button'
 import { User } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
+/** Dropdown to switch the current mock user/role for demo purposes. */
 export function RoleSwitcher() {
   const { currentUser, setCurrentUser } = useAuth()
   const [users, setUsers] = useState<MockUser[]>([])

--- a/components/ShiftModal.tsx
+++ b/components/ShiftModal.tsx
@@ -24,6 +24,7 @@ import { MockUser } from '@/lib/auth/mockAuth'
 import { useAuth } from '@/lib/auth/mockAuth'
 import { formatTime, formatDateDisplay, formatDayName } from '@/lib/date-utils'
 
+/** Shift type metadata used for labeling and default times. */
 export interface ShiftType {
   id: string
   code: string
@@ -34,6 +35,7 @@ export interface ShiftType {
   crossesMidnight: boolean
 }
 
+/** Shift domain model used by the schedule UI. */
 export interface Shift {
   id: string
   userId: string
@@ -56,6 +58,7 @@ interface ShiftModalProps {
   currentUser: MockUser | null
 }
 
+/** Modal for viewing, creating, or updating a single shift. */
 export function ShiftModal({ shift, date, userId, onClose, currentUser }: ShiftModalProps) {
   const { canEditShifts } = useAuth()
   const [shiftTypes, setShiftTypes] = useState<ShiftType[]>([])

--- a/components/ShiftModal.tsx
+++ b/components/ShiftModal.tsx
@@ -24,7 +24,7 @@ import { MockUser } from '@/lib/auth/mockAuth'
 import { useAuth } from '@/lib/auth/mockAuth'
 import { formatTime, formatDateDisplay, formatDayName } from '@/lib/date-utils'
 
-interface ShiftType {
+export interface ShiftType {
   id: string
   code: string
   label: string
@@ -34,7 +34,7 @@ interface ShiftType {
   crossesMidnight: boolean
 }
 
-interface Shift {
+export interface Shift {
   id: string
   userId: string
   date: string
@@ -96,12 +96,13 @@ export function ShiftModal({ shift, date, userId, onClose, currentUser }: ShiftM
   }, [shift, date, shiftTypes])
 
   const handleSave = async () => {
-    if (!date || !selectedShiftTypeId || !selectedUserId) return
+    const effectiveDate = shift?.date ?? date
+    if (!effectiveDate || !selectedShiftTypeId || !selectedUserId) return
 
     setIsSaving(true)
     try {
       const shiftData = {
-        date,
+        date: effectiveDate,
         userId: selectedUserId,
         shiftTypeId: selectedShiftTypeId,
         startTime,

--- a/components/WeekGrid.tsx
+++ b/components/WeekGrid.tsx
@@ -5,26 +5,8 @@ import { format } from 'date-fns'
 import { nb } from 'date-fns/locale/nb'
 import { formatHours, calculateShiftHours } from '@/lib/date-utils'
 import { ShiftModal } from './ShiftModal'
+import type { Shift } from './ShiftModal'
 import { MockUser } from '@/lib/auth/mockAuth'
-
-interface Shift {
-  id: string
-  userId: string
-  date: string
-  startDateTime: string
-  endDateTime: string
-  shiftType: {
-    id: string
-    code: string
-    label: string
-    color: string
-  }
-  user: {
-    id: string
-    name: string
-  }
-  comment?: string
-}
 
 interface WeekGridProps {
   weekDates: Date[]
@@ -33,6 +15,7 @@ interface WeekGridProps {
   currentUser: MockUser | null
 }
 
+/** Render the weekly schedule grid with per-user totals and shift editing. */
 export function WeekGrid({ weekDates, users, shifts, currentUser }: WeekGridProps) {
   const [selectedShift, setSelectedShift] = useState<Shift | null>(null)
   const [selectedDate, setSelectedDate] = useState<string | null>(null)

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,6 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
+/** Variant map for button styling. */
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
@@ -33,11 +34,13 @@ const buttonVariants = cva(
   } as const
 )
 
+/** Props for the shared Button component. */
 export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
   }
 
+/** Shared button component with variant and size support. */
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -4,14 +4,19 @@ import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+/** Root dialog container. */
 const Dialog = DialogPrimitive.Root
 
+/** Element that opens the dialog. */
 const DialogTrigger = DialogPrimitive.Trigger
 
+/** Portal wrapper for dialog content. */
 const DialogPortal = DialogPrimitive.Portal
 
+/** Close control for the dialog. */
 const DialogClose = DialogPrimitive.Close
 
+/** Full-screen overlay behind the dialog. */
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
@@ -27,6 +32,7 @@ const DialogOverlay = React.forwardRef<
 ))
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
+/** Dialog content container with default styling. */
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
@@ -51,6 +57,7 @@ const DialogContent = React.forwardRef<
 ))
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
+/** Header section for dialog titles and descriptions. */
 const DialogHeader = ({
   className,
   ...props
@@ -65,6 +72,7 @@ const DialogHeader = ({
 )
 DialogHeader.displayName = "DialogHeader"
 
+/** Footer section for dialog actions. */
 const DialogFooter = ({
   className,
   ...props
@@ -79,6 +87,7 @@ const DialogFooter = ({
 )
 DialogFooter.displayName = "DialogFooter"
 
+/** Dialog title text. */
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
@@ -94,6 +103,7 @@ const DialogTitle = React.forwardRef<
 ))
 DialogTitle.displayName = DialogPrimitive.Title.displayName
 
+/** Dialog description text. */
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -4,18 +4,25 @@ import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+/** Root dropdown menu container. */
 const DropdownMenu = DropdownMenuPrimitive.Root
 
+/** Trigger element that opens the dropdown menu. */
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
 
+/** Group wrapper for related menu items. */
 const DropdownMenuGroup = DropdownMenuPrimitive.Group
 
+/** Portal wrapper for dropdown content. */
 const DropdownMenuPortal = DropdownMenuPrimitive.Portal
 
+/** Submenu container for nested items. */
 const DropdownMenuSub = DropdownMenuPrimitive.Sub
 
+/** Radio group for mutually exclusive menu items. */
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
 
+/** Trigger for opening a submenu. */
 const DropdownMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
@@ -38,6 +45,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
 DropdownMenuSubTrigger.displayName =
   DropdownMenuPrimitive.SubTrigger.displayName
 
+/** Container for submenu content. */
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
@@ -54,6 +62,7 @@ const DropdownMenuSubContent = React.forwardRef<
 DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName
 
+/** Container for dropdown menu content. */
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
@@ -72,6 +81,7 @@ const DropdownMenuContent = React.forwardRef<
 ))
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
+/** Standard dropdown menu item. */
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
@@ -90,6 +100,7 @@ const DropdownMenuItem = React.forwardRef<
 ))
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
 
+/** Checkbox-style dropdown item. */
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
@@ -114,6 +125,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 DropdownMenuCheckboxItem.displayName =
   DropdownMenuPrimitive.CheckboxItem.displayName
 
+/** Radio-style dropdown item. */
 const DropdownMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
@@ -136,6 +148,7 @@ const DropdownMenuRadioItem = React.forwardRef<
 ))
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
 
+/** Label text for a menu section. */
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
@@ -154,6 +167,7 @@ const DropdownMenuLabel = React.forwardRef<
 ))
 DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
 
+/** Separator line between menu sections. */
 const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
@@ -166,6 +180,7 @@ const DropdownMenuSeparator = React.forwardRef<
 ))
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
 
+/** Right-aligned shortcut hint text for a menu item. */
 const DropdownMenuShortcut = ({
   className,
   ...props

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -2,9 +2,11 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+/** Props for the shared Input component. */
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
 
+/** Shared input component with consistent styling. */
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {
     return (

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -8,6 +8,7 @@ const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 )
 
+/** Shared label component with consistent typography. */
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -4,12 +4,16 @@ import { Check, ChevronDown, ChevronUp } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+/** Root select component. */
 const Select = SelectPrimitive.Root
 
+/** Group wrapper for select options. */
 const SelectGroup = SelectPrimitive.Group
 
+/** Displayed value for the select trigger. */
 const SelectValue = SelectPrimitive.Value
 
+/** Trigger button for opening the select menu. */
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
@@ -30,6 +34,7 @@ const SelectTrigger = React.forwardRef<
 ))
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
 
+/** Scroll-up control for long option lists. */
 const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
@@ -47,6 +52,7 @@ const SelectScrollUpButton = React.forwardRef<
 ))
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
 
+/** Scroll-down control for long option lists. */
 const SelectScrollDownButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
@@ -65,6 +71,7 @@ const SelectScrollDownButton = React.forwardRef<
 SelectScrollDownButton.displayName =
   SelectPrimitive.ScrollDownButton.displayName
 
+/** Container for select options. */
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
@@ -97,6 +104,7 @@ const SelectContent = React.forwardRef<
 ))
 SelectContent.displayName = SelectPrimitive.Content.displayName
 
+/** Label for a group of select options. */
 const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
@@ -109,6 +117,7 @@ const SelectLabel = React.forwardRef<
 ))
 SelectLabel.displayName = SelectPrimitive.Label.displayName
 
+/** Selectable option item. */
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
@@ -132,6 +141,7 @@ const SelectItem = React.forwardRef<
 ))
 SelectItem.displayName = SelectPrimitive.Item.displayName
 
+/** Separator line between option groups. */
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -5,8 +5,10 @@ import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+/** Root provider for toast notifications. */
 const ToastProvider = ToastPrimitives.Provider
 
+/** Container where toasts are rendered. */
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
@@ -38,6 +40,7 @@ const toastVariants = cva(
   }
 )
 
+/** Toast root component with variant support. */
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
@@ -53,6 +56,7 @@ const Toast = React.forwardRef<
 })
 Toast.displayName = ToastPrimitives.Root.displayName
 
+/** Optional action button inside a toast. */
 const ToastAction = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Action>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
@@ -68,6 +72,7 @@ const ToastAction = React.forwardRef<
 ))
 ToastAction.displayName = ToastPrimitives.Action.displayName
 
+/** Close button for a toast. */
 const ToastClose = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Close>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
@@ -86,6 +91,7 @@ const ToastClose = React.forwardRef<
 ))
 ToastClose.displayName = ToastPrimitives.Close.displayName
 
+/** Title text within a toast. */
 const ToastTitle = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Title>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
@@ -98,6 +104,7 @@ const ToastTitle = React.forwardRef<
 ))
 ToastTitle.displayName = ToastPrimitives.Title.displayName
 
+/** Description text within a toast. */
 const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
@@ -110,8 +117,10 @@ const ToastDescription = React.forwardRef<
 ))
 ToastDescription.displayName = ToastPrimitives.Description.displayName
 
+/** Props for the Toast component. */
 type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
 
+/** Element type for custom toast actions. */
 type ToastActionElement = React.ReactElement<typeof ToastAction>
 
 export {

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/toast"
 import { useToast } from "@/components/ui/use-toast"
 
+/** Renders the toast stack using the shared toast store. */
 export function Toaster() {
   const { toasts } = useToast()
 

--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -68,6 +68,7 @@ const addToRemoveQueue = (toastId: string) => {
   toastTimeouts.set(toastId, timeout)
 }
 
+/** Reducer for toast state transitions. */
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case "ADD_TOAST":
@@ -134,6 +135,7 @@ function dispatch(action: Action) {
 
 type Toast = Omit<ToasterToast, "id">
 
+/** Create and show a toast, returning controls for update/dismiss. */
 function toast({ ...props }: Toast) {
   const id = genId()
 
@@ -163,6 +165,7 @@ function toast({ ...props }: Toast) {
   }
 }
 
+/** Hook to access toast state and dispatch helpers. */
 function useToast() {
   const [state, setState] = React.useState<State>(memoryState)
 

--- a/lib/auth/mockAuth.ts
+++ b/lib/auth/mockAuth.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { UserRole } from '@prisma/client'
 
+/** Lightweight user shape used by the mock auth store. */
 export interface MockUser {
   id: string
   name: string
@@ -19,6 +20,7 @@ interface AuthState {
   canApproveSwaps: () => boolean
 }
 
+/** Mock auth store with role-based helpers for UI gating. */
 export const useAuth = create<AuthState>((set, get) => ({
   currentUser: null,
   setCurrentUser: (user) => set({ currentUser: user }),

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -1,55 +1,68 @@
 import { format, startOfWeek, endOfWeek, addWeeks, subWeeks, parse, isSameDay, addDays, differenceInHours, differenceInMinutes } from 'date-fns'
 import { nb } from 'date-fns/locale/nb'
 
+/** Date-only format used across the app (YYYY-MM-DD). */
 export const DATE_FORMAT = 'yyyy-MM-dd'
+/** Date-time format used for persisted shift timestamps. */
 export const DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm"
 
+/** Normalize a date value to the app's DATE_FORMAT. */
 export function formatDate(date: Date | string): string {
   const d = typeof date === 'string' ? parse(date, DATE_FORMAT, new Date()) : date
   return format(d, DATE_FORMAT)
 }
 
+/** Format a date value to the app's DATETIME_FORMAT. */
 export function formatDateTime(date: Date | string): string {
   const d = typeof date === 'string' ? new Date(date) : date
   return format(d, DATETIME_FORMAT)
 }
 
+/** Format a date value as a clock time (HH:mm). */
 export function formatTime(date: Date | string): string {
   const d = typeof date === 'string' ? new Date(date) : date
   return format(d, 'HH:mm')
 }
 
+/** Format a date for human-readable display in Norwegian. */
 export function formatDateDisplay(date: Date | string): string {
   const d = typeof date === 'string' ? parse(date, DATE_FORMAT, new Date()) : date
   return format(d, 'dd.MM.yyyy', { locale: nb })
 }
 
+/** Get the localized weekday name for a date. */
 export function formatDayName(date: Date | string): string {
   const d = typeof date === 'string' ? parse(date, DATE_FORMAT, new Date()) : date
   return format(d, 'EEEE', { locale: nb })
 }
 
+/** Get the start of the week (Monday) for the provided date. */
 export function getWeekStart(date: Date = new Date()): Date {
   return startOfWeek(date, { weekStartsOn: 1 }) // Monday
 }
 
+/** Get the end of the week (Sunday) for the provided date. */
 export function getWeekEnd(date: Date = new Date()): Date {
   return endOfWeek(date, { weekStartsOn: 1 }) // Monday
 }
 
+/** Build a 7-day list for the week containing the provided date. */
 export function getWeekDates(date: Date = new Date()): Date[] {
   const start = getWeekStart(date)
   return Array.from({ length: 7 }, (_, i) => addDays(start, i))
 }
 
+/** Shift a date forward by a number of weeks. */
 export function addWeek(date: Date, weeks: number = 1): Date {
   return addWeeks(date, weeks)
 }
 
+/** Shift a date backward by a number of weeks. */
 export function subWeek(date: Date, weeks: number = 1): Date {
   return subWeeks(date, weeks)
 }
 
+/** Calculate shift length in hours from start and end timestamps. */
 export function calculateShiftHours(startDateTime: Date | string, endDateTime: Date | string): number {
   const start = typeof startDateTime === 'string' ? new Date(startDateTime) : startDateTime
   const end = typeof endDateTime === 'string' ? new Date(endDateTime) : endDateTime
@@ -58,6 +71,7 @@ export function calculateShiftHours(startDateTime: Date | string, endDateTime: D
   return minutes / 60
 }
 
+/** Format decimal hours as H:mm for display. */
 export function formatHours(hours: number): string {
   const h = Math.floor(hours)
   const m = Math.round((hours - h) * 60)

--- a/lib/notifications/sendEmail.ts
+++ b/lib/notifications/sendEmail.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma'
 
+/** Payload for sending and storing an email notification. */
 export interface EmailNotification {
   to: string
   subject: string
@@ -9,6 +10,7 @@ export interface EmailNotification {
   type: string
 }
 
+/** Send an email notification (stubbed) and persist it in the database. */
 export async function sendEmail(notification: EmailNotification): Promise<void> {
   // Stub implementation - logs to console and stores in Notification table
   console.log('📧 Email notification:', {

--- a/lib/notifications/sendSms.ts
+++ b/lib/notifications/sendSms.ts
@@ -1,4 +1,5 @@
 // Placeholder for future SMS endpoint integration
+/** Payload for sending an SMS notification. */
 export interface SmsNotification {
   to: string
   message: string
@@ -6,6 +7,7 @@ export interface SmsNotification {
   userId?: string
 }
 
+/** Send an SMS notification (stub implementation). */
 export async function sendSms(notification: SmsNotification): Promise<void> {
   // Stub implementation - placeholder for existing SMS endpoint integration
   console.log('📱 SMS notification (stub):', {

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -4,6 +4,7 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
 }
 
+/** Shared Prisma client to avoid exhausting connections in dev. */
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,7 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+/** Merge conditional class names with Tailwind conflict resolution. */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }


### PR DESCRIPTION
## What changed?
- Added bulk shifts. Ignore the size of the changed files. Many of the editet files are comments

## Why?
- NA

## How to test?
- NA

## Screenshots (UI changes)
-

## Checklist
- [ x] I ran the app locally
- [ x] I kept the PR small and focused
- [ x] No secrets (.env, tokens) were committed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new write-path logic that can mass-create/update/delete shifts and notifications; although inputs are validated and role-gated, mistakes or edge cases could impact many records at once.
> 
> **Overview**
> Adds **bulk shift editing**: a new `BulkShiftModal` in the standard weekly view (gated by `canEditShifts()` and selected team) lets admins/leaders create/update/delete multiple shifts in one operation, with row duplication, optional custom times, and partial-failure reporting.
> 
> Introduces a new backend endpoint `POST /api/shifts/bulk` that validates input (role, team membership, date/time formats, max 200 items), processes requests in batches, handles cross-midnight shifts, and emits `SHIFT_CREATED`/`SHIFT_UPDATED`/`SHIFT_DELETED` notifications per affected user. Minor related changes include exporting shared `Shift` types for reuse and a small fix in `ShiftModal` to ensure updates use the shift’s date; many other diffs are comment-only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cddb04ea3653e690f3a84be46bd280b1e4f51634. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->