### PR TITLE
chore(docs): add auto architecture generator

### DIFF
--- a/.github/workflows/update-architecture.yml
+++ b/.github/workflows/update-architecture.yml
@@ -1,0 +1,37 @@
+name: Update architecture docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-architecture:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip docs]') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate architecture docs
+        run: npm run docs:architecture
+
+      - name: Commit README updates
+        run: |
+          if git diff --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "chore(docs): update architecture [skip docs]"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,5 +1,235 @@
 # HDO Turnusplan MVP
 
+<!-- AUTO-GENERATED-ARCHITECTURE-START -->
+## Application Architecture
+
+```mermaid
+flowchart TD
+  subgraph "UI (App Router)"
+    N1["app/(app)/admin/audit/page.tsx"]
+    N2["app/(app)/admin/settings/page.tsx"]
+    N3["app/(app)/admin/shift-types/page.tsx"]
+    N4["app/(app)/admin/teams/page.tsx"]
+    N5["app/(app)/admin/users/page.tsx"]
+    N6["app/(app)/agenda/page.tsx"]
+    N7["app/(app)/month/page.tsx"]
+    N8["app/(app)/standard/page.tsx"]
+    N9["app/(app)/swap/page.tsx"]
+    N10["components/auth/RoleSwitcher.tsx"]
+    N11["components/BulkShiftModal.tsx"]
+    N12["components/layout/NotificationsPanel.tsx"]
+    N13["components/schedule/ShiftModal.tsx"]
+    N14["components/ShiftModal.tsx"]
+  end
+  subgraph "API Routes"
+    N15["app/api/admin/audit/route.ts"]
+    N16["app/api/admin/users/route.ts"]
+    N17["app/api/teams/route.ts"]
+    N18["app/api/notification-settings/route.ts"]
+    N19["app/api/users/[id]/notification-preferences/route.ts"]
+    N20["app/api/shift-types/[id]/route.ts"]
+    N21["app/api/shift-types/route.ts"]
+    N22["app/api/teams/[id]/route.ts"]
+    N23["app/api/admin/teams/[teamId]/members/route.ts"]
+    N24["app/api/admin/teams/[teamId]/members/[membershipId]/route.ts"]
+    N25["app/api/admin/users/[id]/route.ts"]
+    N26["app/api/shifts/route.ts"]
+    N27["app/api/notes/route.ts"]
+    N28["app/api/users/route.ts"]
+    N29["app/api/swap-requests/route.ts"]
+    N30["app/api/swap-requests/[id]/approve/route.ts"]
+    N31["app/api/swap-requests/[id]/reject/route.ts"]
+    N32["app/api/swap-requests/[id]/execute/route.ts"]
+    N33["app/api/shifts/bulk/route.ts"]
+    N34["app/api/notifications/route.ts"]
+    N35["app/api/notifications/[id]/read/route.ts"]
+    N36["app/api/notes/[id]/approve/route.ts"]
+    N37["app/api/shifts/[id]/route.ts"]
+    N38["app/api/users/[id]/route.ts"]
+  end
+  subgraph "Data Access"
+    N39["lib/prisma.ts"]
+  end
+  N1 --> N15
+  N1 --> N16
+  N1 --> N17
+  N2 --> N18
+  N2 --> N19
+  N2 --> N17
+  N3 --> N20
+  N3 --> N21
+  N4 --> N22
+  N4 --> N17
+  N5 --> N16
+  N5 --> N23
+  N5 --> N24
+  N5 --> N25
+  N5 --> N17
+  N6 --> N26
+  N6 --> N27
+  N6 --> N17
+  N6 --> N28
+  N7 --> N26
+  N7 --> N17
+  N8 --> N28
+  N8 --> N26
+  N8 --> N17
+  N9 --> N28
+  N9 --> N29
+  N9 --> N26
+  N9 --> N30
+  N9 --> N31
+  N9 --> N32
+  N9 --> N17
+  N10 --> N28
+  N11 --> N26
+  N11 --> N21
+  N11 --> N28
+  N11 --> N33
+  N12 --> N34
+  N12 --> N35
+  N13 --> N33
+  N13 --> N21
+  N13 --> N28
+  N14 --> N33
+  N14 --> N21
+  N14 --> N28
+  N15 --> N39
+  N23 --> N39
+  N24 --> N39
+  N16 --> N39
+  N25 --> N39
+  N27 --> N39
+  N36 --> N39
+  N18 --> N39
+  N34 --> N39
+  N35 --> N39
+  N21 --> N39
+  N20 --> N39
+  N33 --> N39
+  N26 --> N39
+  N37 --> N39
+  N29 --> N39
+  N30 --> N39
+  N32 --> N39
+  N31 --> N39
+  N17 --> N39
+  N22 --> N39
+  N28 --> N39
+  N19 --> N39
+  N38 --> N39
+```
+
+## Component Hierarchy
+
+```mermaid
+graph TD
+  N1["app/(app)/admin/layout.tsx"]
+  N2["app/(app)/layout.tsx"]
+  N3["app/(app)/settings/layout.tsx"]
+  N4["app/layout.tsx"]
+  N5["app/(app)/admin/audit/page.tsx"]
+  N6["app/(app)/admin/page.tsx"]
+  N7["app/(app)/admin/settings/page.tsx"]
+  N8["app/(app)/admin/shift-types/page.tsx"]
+  N9["app/(app)/admin/teams/page.tsx"]
+  N10["app/(app)/admin/users/page.tsx"]
+  N11["app/(app)/agenda/page.tsx"]
+  N12["app/(app)/month/page.tsx"]
+  N13["app/(app)/page.tsx"]
+  N14["app/(app)/settings/page.tsx"]
+  N15["app/(app)/settings/users/page.tsx"]
+  N16["app/(app)/standard/page.tsx"]
+  N17["app/(app)/swap/page.tsx"]
+  N18["app/page.tsx"]
+  N19["components/ui/button.tsx"]
+  N20["components/ui/dialog.tsx"]
+  N21["components/ui/select.tsx"]
+  N22["components/ui/input.tsx"]
+  N23["components/ui/label.tsx"]
+  N24["components/schedule/WeekGrid.tsx"]
+  N25["components/BulkShiftModal.tsx"]
+  N26["components/schedule/ShiftModal.tsx"]
+  N27["components/layout/Navigation.tsx"]
+  N28["components/ui/toaster.tsx"]
+  N29["components/ui/toast.tsx"]
+  N30["components/auth/RoleSwitcher.tsx"]
+  N31["components/layout/NotificationsPanel.tsx"]
+  N32["components/ui/dropdown-menu.tsx"]
+  N2 --> N1
+  N4 --> N2
+  N2 --> N3
+  N1 --> N5
+  N1 --> N6
+  N1 --> N7
+  N1 --> N8
+  N1 --> N9
+  N1 --> N10
+  N2 --> N11
+  N2 --> N12
+  N2 --> N13
+  N3 --> N14
+  N3 --> N15
+  N2 --> N16
+  N2 --> N17
+  N4 --> N18
+  N17 --> N19
+  N17 --> N20
+  N17 --> N21
+  N17 --> N22
+  N17 --> N23
+  N16 --> N19
+  N16 --> N24
+  N16 --> N25
+  N25 --> N19
+  N25 --> N22
+  N25 --> N23
+  N25 --> N20
+  N25 --> N21
+  N24 --> N26
+  N26 --> N20
+  N26 --> N19
+  N26 --> N22
+  N26 --> N23
+  N26 --> N21
+  N12 --> N19
+  N12 --> N26
+  N11 --> N19
+  N11 --> N21
+  N10 --> N19
+  N10 --> N22
+  N10 --> N23
+  N10 --> N20
+  N10 --> N21
+  N9 --> N19
+  N9 --> N22
+  N9 --> N23
+  N9 --> N20
+  N8 --> N19
+  N8 --> N22
+  N8 --> N23
+  N8 --> N20
+  N7 --> N19
+  N7 --> N22
+  N7 --> N23
+  N7 --> N21
+  N6 --> N19
+  N5 --> N19
+  N5 --> N21
+  N2 --> N27
+  N2 --> N28
+  N28 --> N29
+  N27 --> N19
+  N27 --> N30
+  N27 --> N31
+  N31 --> N19
+  N31 --> N20
+  N30 --> N32
+  N30 --> N19
+```
+<!-- AUTO-GENERATED-ARCHITECTURE-END -->
+
+
 En moderne web-basert vaktplanleggingssystem (turnusplan) for Helsetjenestens driftsorganisasjon for nødnett HF (HDO). 
 
 ## Teknologier

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "db:push": "prisma db push",
     "db:seed": "tsx prisma/seed.ts",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "docs:architecture": "tsx scripts/generate-architecture-docs.ts"
   },
   "dependencies": {
     "next": "^14.2.0",

--- a/scripts/generate-architecture-docs.ts
+++ b/scripts/generate-architecture-docs.ts
@@ -1,0 +1,482 @@
+import fs from "fs"
+import path from "path"
+
+const repoRoot = process.cwd()
+const ignoredDirs = new Set(["node_modules", ".next", ".git", "dist", "build", "out", "coverage"])
+const supportedExts = [".tsx", ".ts", ".jsx", ".js"]
+
+const importRegexes = [
+  /import\s+(?:type\s+)?[^'"]*?\sfrom\s+['"]([^'"]+)['"]/g,
+  /import\s*['"]([^'"]+)['"]/g,
+  /import\(\s*['"]([^'"]+)['"]\s*\)/g,
+]
+
+const fetchRegexes = [
+  /fetch\(\s*`([^`]+)`/g,
+  /fetch\(\s*'([^']+)'/g,
+  /fetch\(\s*"([^"]+)"/g,
+]
+
+function walk(dir: string, files: string[] = []): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (!ignoredDirs.has(entry.name)) {
+        walk(fullPath, files)
+      }
+      continue
+    }
+    files.push(fullPath)
+  }
+  return files
+}
+
+function readJson(filePath: string) {
+  const raw = fs.readFileSync(filePath, "utf8")
+  return JSON.parse(raw)
+}
+
+function normalizePath(filePath: string) {
+  return filePath.replace(/\\/g, "/")
+}
+
+function toRelative(filePath: string) {
+  return normalizePath(path.relative(repoRoot, filePath))
+}
+
+function resolveImport(spec: string, fromFile: string, appRoot: string) {
+  let basePath: string | null = null
+  if (spec.startsWith("./") || spec.startsWith("../")) {
+    basePath = path.resolve(path.dirname(fromFile), spec)
+  } else if (spec.startsWith("@/")) {
+    basePath = path.resolve(appRoot, spec.slice(2))
+  } else {
+    return null
+  }
+
+  const ext = path.extname(basePath)
+  if (ext && supportedExts.includes(ext) && fs.existsSync(basePath)) {
+    return basePath
+  }
+
+  for (const suffix of supportedExts) {
+    const candidate = `${basePath}${suffix}`
+    if (fs.existsSync(candidate)) return candidate
+  }
+
+  for (const suffix of supportedExts) {
+    const candidate = path.join(basePath, `index${suffix}`)
+    if (fs.existsSync(candidate)) return candidate
+  }
+
+  return null
+}
+
+function getImports(filePath: string, cache: Map<string, string>) {
+  if (!cache.has(filePath)) {
+    cache.set(filePath, fs.readFileSync(filePath, "utf8"))
+  }
+  const content = cache.get(filePath) ?? ""
+  const imports: string[] = []
+  for (const regex of importRegexes) {
+    let match: RegExpExecArray | null
+    while ((match = regex.exec(content)) !== null) {
+      imports.push(match[1])
+    }
+  }
+  return imports
+}
+
+function extractFetchApiPaths(filePath: string, cache: Map<string, string>) {
+  if (!cache.has(filePath)) {
+    cache.set(filePath, fs.readFileSync(filePath, "utf8"))
+  }
+  const content = cache.get(filePath) ?? ""
+  const paths: string[] = []
+  for (const regex of fetchRegexes) {
+    let match: RegExpExecArray | null
+    while ((match = regex.exec(content)) !== null) {
+      const raw = match[1]
+      if (raw.startsWith("/api")) {
+        paths.push(raw)
+      }
+    }
+  }
+  return paths
+}
+
+function findNextAppRoot(allFiles: string[]) {
+  const packageFiles = allFiles.filter((file) => path.basename(file) === "package.json")
+  const candidates: { dir: string; hasNext: boolean }[] = []
+
+  for (const pkgFile of packageFiles) {
+    const dir = path.dirname(pkgFile)
+    try {
+      const pkg = readJson(pkgFile)
+      const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) }
+      const hasNext = typeof deps.next === "string"
+      candidates.push({ dir, hasNext })
+    } catch {
+      // ignore invalid json
+    }
+  }
+
+  const nextCandidates = candidates.filter((c) => c.hasNext)
+  if (nextCandidates.length === 0) return null
+
+  for (const candidate of nextCandidates) {
+    const appDir = path.join(candidate.dir, "app")
+    if (fs.existsSync(appDir) && fs.statSync(appDir).isDirectory()) {
+      return candidate.dir
+    }
+  }
+
+  return nextCandidates[0]?.dir ?? null
+}
+
+function findReadmePath(allFiles: string[], appRoot: string) {
+  const appReadme = path.join(appRoot, "README.md")
+  if (fs.existsSync(appReadme)) return appReadme
+
+  const readmes = allFiles.filter((file) => path.basename(file).toLowerCase() === "readme.md")
+  if (readmes.length === 0) return null
+
+  const sorted = readmes.sort((a, b) => {
+    const aRel = path.relative(appRoot, a)
+    const bRel = path.relative(appRoot, b)
+    return aRel.length - bRel.length
+  })
+  return sorted[0]
+}
+
+function buildApiPattern(filePath: string, appDir: string) {
+  const rel = path.relative(appDir, filePath)
+  const parts = rel.split(path.sep)
+  const apiIndex = parts.indexOf("api")
+  if (apiIndex === -1) return null
+  const withoutFile = parts.slice(apiIndex + 1, parts.length - 1)
+  const routePath = `/api/${withoutFile.join("/")}`
+  return { routePath, parts: withoutFile, filePath }
+}
+
+function segmentIsWildcard(segment: string) {
+  return segment.startsWith("[") && segment.endsWith("]")
+}
+
+function segmentIsCatchAll(segment: string) {
+  return segment.startsWith("[...") && segment.endsWith("]")
+}
+
+function matchApiPattern(requestSegments: string[], patternSegments: string[]) {
+  let i = 0
+  let j = 0
+  while (i < requestSegments.length && j < patternSegments.length) {
+    const req = requestSegments[i]
+    const pat = patternSegments[j]
+    if (segmentIsCatchAll(pat)) return true
+    if (segmentIsWildcard(pat) || req.includes("${")) {
+      i += 1
+      j += 1
+      continue
+    }
+    if (req !== pat) return false
+    i += 1
+    j += 1
+  }
+  if (i === requestSegments.length && j === patternSegments.length) return true
+  if (j < patternSegments.length && segmentIsCatchAll(patternSegments[j])) return true
+  return false
+}
+
+function scorePattern(patternSegments: string[]) {
+  return patternSegments.reduce((score, segment) => {
+    if (segmentIsCatchAll(segment)) return score - 2
+    if (segmentIsWildcard(segment)) return score - 1
+    return score + 2
+  }, 0)
+}
+
+function selectBestApiMatch(requestPath: string, apiPatterns: ReturnType<typeof buildApiPattern>[]) {
+  const pathOnly = requestPath.split("?")[0]
+  const reqSegments = pathOnly.replace(/^\/+/, "").split("/").slice(1)
+  const matches = apiPatterns
+    .filter((pattern) => pattern && matchApiPattern(reqSegments, pattern.parts))
+    .map((pattern) => ({ pattern, score: scorePattern(pattern!.parts) }))
+    .sort((a, b) => b.score - a.score)
+
+  return matches[0]?.pattern ?? null
+}
+
+function buildMermaidNodes(
+  files: string[],
+  idMap: Map<string, string>,
+  labels: Map<string, string>
+) {
+  const nodes: string[] = []
+  for (const file of files) {
+    if (!idMap.has(file)) {
+      idMap.set(file, `N${idMap.size + 1}`)
+    }
+    const id = idMap.get(file) as string
+    if (!labels.has(id)) {
+      labels.set(id, toRelative(file))
+    }
+    nodes.push(`${id}["${labels.get(id)}"]`)
+  }
+  return nodes
+}
+
+function renderEdges(edges: Array<[string, string]>, idMap: Map<string, string>) {
+  return edges.map(([from, to]) => {
+    const fromId = idMap.get(from) as string
+    const toId = idMap.get(to) as string
+    return `${fromId} --> ${toId}`
+  })
+}
+
+function main() {
+  const allFiles = walk(repoRoot)
+  const appRoot = findNextAppRoot(allFiles)
+  if (!appRoot) {
+    throw new Error("No Next.js app root found.")
+  }
+
+  const appDir = path.join(appRoot, "app")
+  const readmePath = findReadmePath(allFiles, appRoot)
+  if (!readmePath) {
+    throw new Error("No README.md found.")
+  }
+
+  const tsFiles = allFiles.filter((file) => [".ts", ".tsx"].includes(path.extname(file)))
+  const pageFiles = tsFiles.filter((file) => normalizePath(file).includes("/app/") && file.endsWith("page.tsx"))
+  const layoutFiles = tsFiles.filter((file) => normalizePath(file).includes("/app/") && file.endsWith("layout.tsx"))
+  const apiFiles = tsFiles.filter((file) => {
+    const rel = normalizePath(path.relative(appDir, file))
+    if (!rel.startsWith("api/")) return false
+    const base = path.basename(file)
+    return ["route.ts", "route.tsx", "page.ts", "page.tsx", "handler.ts", "handler.tsx"].includes(base)
+  })
+
+  const contentCache = new Map<string, string>()
+  const importCache = new Map<string, string[]>()
+
+  function getImportsCached(filePath: string) {
+    if (!importCache.has(filePath)) {
+      const imports = getImports(filePath, contentCache)
+      importCache.set(filePath, imports)
+    }
+    return importCache.get(filePath) ?? []
+  }
+
+  const layoutByDir = new Map<string, string>()
+  for (const layoutFile of layoutFiles) {
+    layoutByDir.set(path.dirname(layoutFile), layoutFile)
+  }
+
+  const hierarchyEdges = new Set<string>()
+  const componentEdges = new Set<string>()
+
+  const addEdge = (set: Set<string>, from: string, to: string) => {
+    set.add(`${from}::${to}`)
+  }
+
+  function findNearestLayout(filePath: string) {
+    let current = path.dirname(filePath)
+    while (current.startsWith(appDir)) {
+      const match = layoutByDir.get(current)
+      if (match) return match
+      const parent = path.dirname(current)
+      if (parent === current) break
+      current = parent
+    }
+    return null
+  }
+
+  for (const layoutFile of layoutFiles) {
+    const parentLayout = findNearestLayout(path.dirname(layoutFile))
+    if (parentLayout && parentLayout !== layoutFile) {
+      addEdge(hierarchyEdges, parentLayout, layoutFile)
+    }
+  }
+
+  for (const pageFile of pageFiles) {
+    const nearestLayout = findNearestLayout(pageFile)
+    if (nearestLayout) {
+      addEdge(hierarchyEdges, nearestLayout, pageFile)
+    }
+  }
+
+  const traversalQueue: string[] = []
+  const visited = new Set<string>()
+
+  function enqueueForTraversal(filePath: string) {
+    if (!visited.has(filePath)) {
+      traversalQueue.push(filePath)
+    }
+  }
+
+  for (const file of [...layoutFiles, ...pageFiles]) {
+    enqueueForTraversal(file)
+  }
+
+  while (traversalQueue.length > 0) {
+    const current = traversalQueue.pop() as string
+    if (visited.has(current)) continue
+    visited.add(current)
+
+    const imports = getImportsCached(current)
+    for (const spec of imports) {
+      const resolved = resolveImport(spec, current, appRoot)
+      if (!resolved) continue
+      if (!resolved.endsWith(".tsx")) continue
+      addEdge(componentEdges, current, resolved)
+      enqueueForTraversal(resolved)
+    }
+  }
+
+  const apiPatterns = apiFiles
+    .map((file) => buildApiPattern(file, appDir))
+    .filter((pattern): pattern is NonNullable<ReturnType<typeof buildApiPattern>> => Boolean(pattern))
+
+  const apiEdges = new Set<string>()
+  const apiNodes = new Set<string>()
+  const uiNodes = new Set<string>()
+
+  for (const file of tsFiles) {
+    if (normalizePath(file).includes("/app/api/")) continue
+    if (!normalizePath(file).startsWith(normalizePath(appRoot))) continue
+    const apiPaths = extractFetchApiPaths(file, contentCache)
+    for (const apiPath of apiPaths) {
+      const match = selectBestApiMatch(apiPath, apiPatterns)
+      if (match) {
+        addEdge(apiEdges, file, match.filePath)
+        apiNodes.add(match.filePath)
+        uiNodes.add(file)
+      }
+    }
+  }
+
+  const prismaPath = path.join(appRoot, "lib", "prisma.ts")
+  const prismaEdges = new Set<string>()
+  const prismaNodes: string[] = []
+
+  if (fs.existsSync(prismaPath)) {
+    for (const apiFile of apiFiles) {
+      const imports = getImportsCached(apiFile)
+      const resolvesToPrisma = imports.some((spec) => {
+        const resolved = resolveImport(spec, apiFile, appRoot)
+        return resolved === prismaPath
+      })
+      if (resolvesToPrisma) {
+        addEdge(prismaEdges, apiFile, prismaPath)
+        apiNodes.add(apiFile)
+        prismaNodes.push(prismaPath)
+      }
+    }
+  }
+
+  const idMap = new Map<string, string>()
+  const labels = new Map<string, string>()
+
+  const architectureUiNodes = Array.from(uiNodes)
+  const architectureApiNodes = Array.from(apiNodes)
+  const architecturePrismaNodes = Array.from(new Set(prismaNodes))
+
+  buildMermaidNodes(architectureUiNodes, idMap, labels)
+  buildMermaidNodes(architectureApiNodes, idMap, labels)
+  buildMermaidNodes(architecturePrismaNodes, idMap, labels)
+
+  const architectureEdges = [...apiEdges, ...prismaEdges].map((edge) => edge.split("::") as [string, string])
+
+  const architectureDiagramLines: string[] = ["flowchart TD"]
+  if (architectureUiNodes.length > 0) {
+    architectureDiagramLines.push(`  subgraph "UI (App Router)"`)
+    for (const node of buildMermaidNodes(architectureUiNodes, idMap, labels)) {
+      architectureDiagramLines.push(`    ${node}`)
+    }
+    architectureDiagramLines.push("  end")
+  }
+  if (architectureApiNodes.length > 0) {
+    architectureDiagramLines.push(`  subgraph "API Routes"`)
+    for (const node of buildMermaidNodes(architectureApiNodes, idMap, labels)) {
+      architectureDiagramLines.push(`    ${node}`)
+    }
+    architectureDiagramLines.push("  end")
+  }
+  if (architecturePrismaNodes.length > 0) {
+    architectureDiagramLines.push(`  subgraph "Data Access"`)
+    for (const node of buildMermaidNodes(architecturePrismaNodes, idMap, labels)) {
+      architectureDiagramLines.push(`    ${node}`)
+    }
+    architectureDiagramLines.push("  end")
+  }
+  for (const edge of renderEdges(architectureEdges, idMap)) {
+    architectureDiagramLines.push(`  ${edge}`)
+  }
+
+  const componentIdMap = new Map<string, string>()
+  const componentLabels = new Map<string, string>()
+  const componentEdgePairs = [...componentEdges].map((edge) => edge.split("::") as [string, string])
+  const hierarchyNodes = Array.from(
+    new Set([...layoutFiles, ...pageFiles, ...componentEdgePairs.flatMap((edge) => edge)])
+  )
+
+  buildMermaidNodes(hierarchyNodes, componentIdMap, componentLabels)
+
+  const hierarchyDiagramLines: string[] = ["graph TD"]
+  for (const node of buildMermaidNodes(hierarchyNodes, componentIdMap, componentLabels)) {
+    hierarchyDiagramLines.push(`  ${node}`)
+  }
+  const allHierarchyEdges = [...hierarchyEdges, ...componentEdges].map(
+    (edge) => edge.split("::") as [string, string]
+  )
+  for (const edge of renderEdges(allHierarchyEdges, componentIdMap)) {
+    hierarchyDiagramLines.push(`  ${edge}`)
+  }
+
+  const architectureDiagram = architectureDiagramLines.join("\n")
+  const hierarchyDiagram = hierarchyDiagramLines.join("\n")
+
+  const startMarker = "<!-- AUTO-GENERATED-ARCHITECTURE-START -->"
+  const endMarker = "<!-- AUTO-GENERATED-ARCHITECTURE-END -->"
+
+  const generatedSection = [
+    startMarker,
+    "## Application Architecture",
+    "",
+    "```mermaid",
+    architectureDiagram,
+    "```",
+    "",
+    "## Component Hierarchy",
+    "",
+    "```mermaid",
+    hierarchyDiagram,
+    "```",
+    endMarker,
+  ].join("\n")
+
+  const readmeContent = fs.readFileSync(readmePath, "utf8")
+  let updatedContent: string
+
+  if (readmeContent.includes(startMarker) && readmeContent.includes(endMarker)) {
+    const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    const pattern = new RegExp(`${escape(startMarker)}[\\s\\S]*?${escape(endMarker)}`, "m")
+    updatedContent = readmeContent.replace(pattern, generatedSection)
+  } else {
+    const lines = readmeContent.split("\n")
+    let insertIndex = 0
+    if (lines[0]?.startsWith("#")) {
+      insertIndex = 1
+      while (lines[insertIndex] === "") insertIndex += 1
+    }
+    const before = lines.slice(0, insertIndex)
+    const after = lines.slice(insertIndex)
+    updatedContent = [...before, "", generatedSection, "", ...after].join("\n")
+  }
+
+  fs.writeFileSync(readmePath, updatedContent, "utf8")
+}
+
+main()


### PR DESCRIPTION
## What changed?
-

## Why?
-

## How to test?
-

## Screenshots (UI changes)
-

## Checklist
- [ ] I ran the app locally
- [ ] I kept the PR small and focused
- [ ] No secrets (.env, tokens) were committed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a GitHub Actions workflow that auto-commits to `main`, which can cause unexpected commit churn or workflow loops if the guardrails fail. The changes are documentation-focused but introduce new CI automation behavior.
> 
> **Overview**
> Introduces an automated architecture-docs pipeline: a new `docs:architecture` script generates Mermaid diagrams (UI→API→Prisma call graph and component/layout hierarchy) and injects/updates them between `<!-- AUTO-GENERATED-ARCHITECTURE-* -->` markers in `README.md`.
> 
> Adds a `Update architecture docs` GitHub Actions workflow that runs on pushes to `main` (unless commit message contains `[skip docs]`), regenerates the section, and auto-commits/pushes `README.md` updates back to the repo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 676939756a244e593d3fcc060703d2bf97670732. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->